### PR TITLE
change logger modes for calls performed by the KubernetesScriptEngineFactory

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.1.2
+version=0.1.3

--- a/src/main/java/jsr223/kubernetes/utils/KubernetesClientVersionGetter.java
+++ b/src/main/java/jsr223/kubernetes/utils/KubernetesClientVersionGetter.java
@@ -81,7 +81,7 @@ public class KubernetesClientVersionGetter {
             Pattern p = Pattern.compile("\\d\\.\\d\\.\\d");
             Matcher m = p.matcher(result);
             if (m.matches()) {
-                log.info("kubectl client version is: " + m.group(0));
+                log.debug("kubectl client version is: " + m.group(0));
                 return m.group(0);
             } else
                 return "Unknown";

--- a/src/main/java/jsr223/kubernetes/utils/KubernetesPropertyLoader.java
+++ b/src/main/java/jsr223/kubernetes/utils/KubernetesPropertyLoader.java
@@ -60,8 +60,8 @@ public class KubernetesPropertyLoader {
             log.debug("Load properties from configuration file: " + CONFIGURATION_FILE);
             properties.load(getClass().getClassLoader().getResourceAsStream(CONFIGURATION_FILE));
         } catch (IOException | NullPointerException e) {
-            log.info("Configuration file " + CONFIGURATION_FILE + " not found. Standard values will be used.");
-            log.debug("Configuration file " + CONFIGURATION_FILE + " not found. Standard values will be used.", e);
+            log.debug("Configuration file " + CONFIGURATION_FILE + " not found. Standard values will be used.");
+            log.trace("Configuration file " + CONFIGURATION_FILE + " not found. Standard values will be used.", e);
         }
 
         // Get property, specify default value


### PR DESCRIPTION
  - this is to avoid polluting logs when the script engine is loaded but not used (example in ProActive Tasks).